### PR TITLE
✨ [#25] 주문 취소

### DIFF
--- a/commerce/src/main/java/com/sparta/commerce/global/exception/ExceptionCode.java
+++ b/commerce/src/main/java/com/sparta/commerce/global/exception/ExceptionCode.java
@@ -23,6 +23,7 @@ public enum ExceptionCode {
   USER_EXISTS(HttpStatus.CONFLICT, "해당 이메일의 회원이 이미 존재합니다."),
   WISH_EXISTS(HttpStatus.CONFLICT, "이미 위시리스트에 등록된 상품입니다."),
   OUT_OF_STOCK(HttpStatus.CONFLICT, "상품 재고가 부족합니다."),
+  ALREADY_SHIPPED(HttpStatus.CONFLICT, "주문 취소는 발송 전까지만 가능합니다."),
 
   // 500
   CREATE_MAIL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메일 생성에 실패했습니다."),

--- a/commerce/src/main/java/com/sparta/commerce/order/controller/OrderController.java
+++ b/commerce/src/main/java/com/sparta/commerce/order/controller/OrderController.java
@@ -2,6 +2,7 @@ package com.sparta.commerce.order.controller;
 
 import com.sparta.commerce.global.security.annotation.UserId;
 import com.sparta.commerce.order.dto.request.OrderCreateRequestDto;
+import com.sparta.commerce.order.dto.response.OrderCancelResponseDto;
 import com.sparta.commerce.order.dto.response.OrderCreateResponseDto;
 import com.sparta.commerce.order.dto.response.OrderInfoDto;
 import com.sparta.commerce.order.dto.response.OrderSummaryDto;
@@ -13,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -43,6 +45,12 @@ public class OrderController {
   @GetMapping("/{orderId}")
   public ResponseEntity<OrderInfoDto> getOrder(@PathVariable Long orderId, @UserId Long userId) {
     OrderInfoDto responseDto = orderService.getOrder(orderId, userId);
+    return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+  }
+
+  @PutMapping("/{orderId}/cancel")
+  public ResponseEntity<OrderCancelResponseDto> cancelOrder(@PathVariable Long orderId, @UserId Long userId) {
+    OrderCancelResponseDto responseDto = orderService.cancelOrder(orderId, userId);
     return ResponseEntity.status(HttpStatus.OK).body(responseDto);
   }
 

--- a/commerce/src/main/java/com/sparta/commerce/order/dto/response/OrderCancelResponseDto.java
+++ b/commerce/src/main/java/com/sparta/commerce/order/dto/response/OrderCancelResponseDto.java
@@ -1,0 +1,23 @@
+package com.sparta.commerce.order.dto.response;
+
+import com.sparta.commerce.order.entity.Order;
+import com.sparta.commerce.order.type.OrderStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class OrderCancelResponseDto {
+
+  private Long orderId;
+  private OrderStatus status;
+
+  public static OrderCancelResponseDto from(Order order) {
+    return OrderCancelResponseDto.builder()
+        .orderId(order.getId())
+        .status(order.getStatus())
+        .build();
+  }
+}

--- a/commerce/src/main/java/com/sparta/commerce/order/entity/Order.java
+++ b/commerce/src/main/java/com/sparta/commerce/order/entity/Order.java
@@ -49,4 +49,8 @@ public class Order extends Timestamped {
         .status(OrderStatus.PREPARING_PRODUCT)
         .build();
   }
+
+  public void cancelOrder() {
+    this.status = OrderStatus.ORDER_CANCELED;
+  }
 }

--- a/commerce/src/main/java/com/sparta/commerce/order/service/OrderService.java
+++ b/commerce/src/main/java/com/sparta/commerce/order/service/OrderService.java
@@ -1,6 +1,7 @@
 package com.sparta.commerce.order.service;
 
 import com.sparta.commerce.order.dto.request.OrderCreateRequestDto;
+import com.sparta.commerce.order.dto.response.OrderCancelResponseDto;
 import com.sparta.commerce.order.dto.response.OrderCreateResponseDto;
 import com.sparta.commerce.order.dto.response.OrderInfoDto;
 import com.sparta.commerce.order.dto.response.OrderSummaryDto;
@@ -13,4 +14,7 @@ public interface OrderService {
   Page<OrderSummaryDto> getOrders(Long userId, int page, int size);
 
   OrderInfoDto getOrder(Long orderId, Long userId);
+
+  OrderCancelResponseDto cancelOrder(Long orderId, Long userId);
+
 }

--- a/commerce/src/main/java/com/sparta/commerce/product/entity/OptionItem.java
+++ b/commerce/src/main/java/com/sparta/commerce/product/entity/OptionItem.java
@@ -37,4 +37,8 @@ public class OptionItem {
   public void deductStock(int quantity) {
     this.stock -= quantity;
   }
+
+  public void addStock(int quantity) {
+    this.stock += quantity;
+  }
 }


### PR DESCRIPTION
## Issue: #22 

#### 작업사항
- 주문 취소 api 구현
  - 주문 상태가 배송중이 되기 이전까지만 취소가 가능
  - 취소 후에 는 상품의 재고를 복구
  - 주문 취소 후 상태는 취소 완료로 변경
- 사용자가 주문 관련 api 를 요청 할 수 있는 권한이 있는지 판별하는 메서드명 변경
  - hasPermissionForGetOrder > hasPermissionForOrder